### PR TITLE
Allow non-destructive updates

### DIFF
--- a/modules/vm/vm.tf
+++ b/modules/vm/vm.tf
@@ -26,7 +26,7 @@ resource "google_compute_instance" "vm" {
   }
 
   lifecycle {
-    create_before_destroy = "true"
+    create_before_destroy = "false"
   }
 
   scheduling {
@@ -55,7 +55,6 @@ resource "google_compute_instance" "vm" {
 
   metadata = {
     ssh-keys = format("%s:%s", var.ssh_user, var.ssh_public_key)
+    startup-script = var.metadata_startup_script
   }
-
-  metadata_startup_script = var.metadata_startup_script
 }


### PR DESCRIPTION
Changing from metadata_startup_script to metadata.startup-script.  metadata_startup_script is ForceNew, so when it is used, all GCP compute instances are destroyed and rebuilt.  See hashicorp/terraform-provider-google#1081.  With ForceNew, the nomad ACL infrastructure (as well as other data) is lost.

I have tested scaling the number of clients and confirmed that this change allows add/remove of clients without destroying the cluster.  I have not tested if it is possible to scale the number of servers.

Also changed create_before_destroy as google_computer_instance does not appear to support creation of instances with the same name.