### PR TITLE
fix(packer): Update template.json to include network and subnetwork vars

### DIFF
--- a/packer/template.json
+++ b/packer/template.json
@@ -1,6 +1,8 @@
 {
     "variables": {
         "project": "{{env `GOOGLE_PROJECT`}}",
+        "network": "default",
+        "subnetwork": "",
         "account_file": "{{env `GOOGLE_APPLICATION_CREDENTIALS`}}",
         "zone": "us-east1-b",
         "disk_size_gb": "10",
@@ -22,6 +24,8 @@
             "state_timeout": "15m",
             "ssh_username": "ubuntu",
             "zone": "{{user `zone`}}",
+            "network": "{{user `network`}}",
+            "subnetwork": "{{user `subnetwork`}}",
             "use_iap": "{{user `use_iap`}}",
             "preemptible": "{{user `use_preemptible`}}"
         },
@@ -38,6 +42,8 @@
             "state_timeout": "15m",
             "ssh_username": "ubuntu",
             "zone": "{{user `zone`}}",
+            "network": "{{user `network`}}",
+            "subnetwork": "{{user `subnetwork`}}",
             "use_iap": "{{user `use_iap`}}",
             "preemptible": "{{user `use_preemptible`}}"
         },
@@ -54,6 +60,8 @@
             "state_timeout": "15m",
             "ssh_username": "ubuntu",
             "zone": "{{user `zone`}}",
+            "network": "{{user `network`}}",
+            "subnetwork": "{{user `subnetwork`}}",
             "use_iap": "{{user `use_iap`}}",
             "preemptible": "{{user `use_preemptible`}}"
         }


### PR DESCRIPTION
If the gcp project does not have a vpc with that name "default" the packer build cannot be executed.

```
$ packer build template.json
bastion: output will be in this color.
client: output will be in this color.
server: output will be in this color.

==> bastion: Checking image does not exist...
==> client: Checking image does not exist...
==> server: Checking image does not exist...
==> client: Creating temporary rsa SSH key for instance...
==> bastion: Creating temporary rsa SSH key for instance...
==> server: Creating temporary rsa SSH key for instance...
==> client: Using image: ubuntu-1804-bionic-v20210108
==> client: Creating instance...
    client: Loading zone: us-east1-b
    client: Loading machine type: n1-standard-1
    client: Requesting instance creation...
==> bastion: Using image: ubuntu-1804-bionic-v20210108
==> bastion: Creating instance...
    bastion: Loading zone: us-east1-b
    bastion: Loading machine type: n1-standard-1
==> server: Using image: ubuntu-1804-bionic-v20210108
==> server: Creating instance...
    server: Loading zone: us-east1-b
    server: Loading machine type: n1-standard-1
    bastion: Requesting instance creation...
    server: Requesting instance creation...
==> client: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.networkInterfaces[0].network': 'global/networks/default'. The referenced network resource cannot be found., invalid
Build 'client' errored after 9 seconds 111 milliseconds: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.networkInterfaces[0].network': 'global/networks/default'. The referenced network resource cannot be found., invalid
==> bastion: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.networkInterfaces[0].network': 'global/networks/default'. The referenced network resource cannot be found., invalid
Build 'bastion' errored after 10 seconds 27 milliseconds: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.networkInterfaces[0].network': 'global/networks/default'. The referenced network resource cannot be found., invalid
==> server: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.networkInterfaces[0].network': 'global/networks/default'. The referenced network resource cannot be found., invalid
Build 'server' errored after 10 seconds 436 milliseconds: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.networkInterfaces[0].network': 'global/networks/default'. The referenced network resource cannot be found., invalid

==> Wait completed after 10 seconds 436 milliseconds

==> Some builds didn't complete successfully and had errors:
--> client: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.networkInterfaces[0].network': 'global/networks/default'. The referenced network resource cannot be found., invalid
--> bastion: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.networkInterfaces[0].network': 'global/networks/default'. The referenced network resource cannot be found., invalid
--> server: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.networkInterfaces[0].network': 'global/networks/default'. The referenced network resource cannot be found., invalid

==> Builds finished but no artifacts were created.

```