### PR TITLE
Add example Cockroach DB job using Consul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,14 @@ nomad/logs: ## Runs a Loki and Promtail jobs on Nomad
 nomad/ingress: ## Runs a Traefik proxy to handle ingress traffic across the cluster
 	@nomad run jobs/ingress/traefik.hcl
 
+.PHONY: nomad/cockroachdb
+nomad/cockroachdb: ## Runs a Cockroach DB cluster
+	@nomad run jobs/db/cockroach.hcl
+	@sleep 10s
+	@nomad alloc exec -i -t=false -task cockroach $(shell nomad status cockroach | grep "running" | grep "cockroach-1" | head -n 1 | awk '{print $$1}') cockroach init --insecure --host=localhost:26258
+	@sleep 10s
+	@nomad alloc exec -i -t=false -task cockroach $(shell nomad status cockroach | grep "running" | grep "cockroach-1" | head -n 1 | awk '{print $$1}') cockroach node ls --insecure --host=localhost:26258
+
 .PHONY: nomad/bootstrap
 nomad/bootstrap: ## Bootstraps the ACL system on the Nomad cluster
 	@nomad acl bootstrap

--- a/jobs/db/cockroach.hcl
+++ b/jobs/db/cockroach.hcl
@@ -15,12 +15,12 @@ job "cockroach" {
   }
 
   constraint {
-      distinct_hosts = true
+    distinct_hosts = true
   }
 
   group "cockroach-1" {
     network {
-        mode = "bridge"
+      mode = "bridge"
     }
 
     service {

--- a/jobs/db/cockroach.hcl
+++ b/jobs/db/cockroach.hcl
@@ -1,0 +1,161 @@
+variable "datacenters" {
+  type    = list(string)
+  default = ["dc1"]
+}
+
+job "cockroach" {
+  datacenters = var.datacenters
+
+  type = "service"
+
+  update {
+    max_parallel     = 1
+    stagger          = "12s"
+    healthy_deadline = "3m"
+  }
+
+  constraint {
+      distinct_hosts = true
+  }
+
+  group "cockroach-1" {
+    network {
+        mode = "bridge"
+    }
+
+    service {
+        name = "cockroach-1"
+        port = "26258"
+
+        connect {
+            sidecar_service {
+                proxy {
+                    upstreams {
+                        destination_name = "cockroach-2"
+                        local_bind_port  = 26259
+                    }
+                    upstreams {
+                        destination_name = "cockroach-3"
+                        local_bind_port  = 26260
+                    }
+                }
+            }
+        }
+    }
+
+    ephemeral_disk {
+      migrate = true
+      sticky  = true
+      size    = 5000 # 5GB
+    }
+
+    task "cockroach" {
+      driver = "docker"
+      config {
+        image = "cockroachdb/cockroach:latest"
+        args = [
+          "start",
+          "--insecure",
+          "--advertise-addr=localhost:26258",
+          "--listen-addr=localhost:26258",
+          "--join=localhost:26258,localhost:26259,localhost:26260",
+          "--logtostderr=INFO",
+        ]
+      }
+    }
+  }
+
+  group "cockroach-2" {
+    network {
+        mode = "bridge"
+    }
+
+    service {
+        name = "cockroach-2"
+        port = "26259"
+
+        connect {
+            sidecar_service {
+                proxy {
+                    upstreams {
+                        destination_name = "cockroach-1"
+                        local_bind_port  = 26258
+                    }
+                    upstreams {
+                        destination_name = "cockroach-3"
+                        local_bind_port  = 26260
+                    }
+                }
+            }
+        }
+    }
+
+    ephemeral_disk {
+      migrate = true
+      sticky  = true
+      size    = 5000 # 5GB
+    }
+
+    task "cockroach" {
+      driver = "docker"
+      config {
+        image = "cockroachdb/cockroach:latest"
+        args = [
+          "start",
+          "--insecure",
+          "--advertise-addr=localhost:26259",
+          "--listen-addr=localhost:26259",
+          "--join=localhost:26258,localhost:26259,localhost:26260",
+          "--logtostderr=INFO",
+        ]
+      }
+    }
+  }
+
+  group "cockroach-3" {
+    network {
+        mode = "bridge"
+    }
+
+    service {
+        name = "cockroach-3"
+        port = "26260"
+
+        connect {
+            sidecar_service {
+                proxy {
+                    upstreams {
+                        destination_name = "cockroach-1"
+                        local_bind_port  = 26258
+                    }
+                    upstreams {
+                        destination_name = "cockroach-2"
+                        local_bind_port  = 26259
+                    }
+                }
+            }
+        }
+    }
+
+    ephemeral_disk {
+      migrate = true
+      sticky  = true
+      size    = 5000 # 5GB
+    }
+
+    task "cockroach" {
+      driver = "docker"
+      config {
+        image = "cockroachdb/cockroach:latest"
+        args = [
+          "start",
+          "--insecure",
+          "--advertise-addr=localhost:26260",
+          "--listen-addr=localhost:26260",
+          "--join=localhost:26258,localhost:26259,localhost:26260",
+          "--logtostderr=INFO",
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds an example Nomad job file to deploy a 3-node Cockroach DB cluster connected with Consul service mesh. The one-time initialization step is also performed in the corresponding make target.