### PR TITLE
Improve Cockroach DB job file example with more service mesh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,13 +188,19 @@ nomad/ingress: ## Runs a Traefik proxy to handle ingress traffic across the clus
 nomad/cockroachdb: ## Runs a Cockroach DB cluster
 	@nomad run jobs/db/cockroach.hcl
 	@sleep 10s
+	@echo "initializing database"
 	@nomad alloc exec -i -t=false -task cockroach $(shell nomad status cockroach | grep "running" | grep "cockroach-1" | head -n 1 | awk '{print $$1}') cockroach init --insecure --host=localhost:26258
 	@sleep 10s
+	@echo "listing nodes"
 	@nomad alloc exec -i -t=false -task cockroach $(shell nomad status cockroach | grep "running" | grep "cockroach-1" | head -n 1 | awk '{print $$1}') cockroach node ls --insecure --host=localhost:26258
 
-.PHONY: cockroachdb
+.PHONY: nomad/cockroachdb/nodes
+nomad/cockroachdb/nodes: ## List all Cockroach DB nodes
+	@nomad alloc exec -i -t=false -task cockroach $(shell nomad status cockroach | grep "running" | grep "cockroach-1" | head -n 1 | awk '{print $$1}') cockroach node ls --insecure --host=localhost:26258
+
+.PHONY: nomad/cockroachdb/sql
 nomad/cockroachdb/sql: ## Start an interactive Cockroach DB SQL shell
-	@nomad alloc exec -i -t=true -task cockroach $(nomad status cockroach | grep "running" | grep "cockroach-1" | head -n 1 | awk '{print $1}') cockroach sql --insecure --host=localhost:26258
+	@nomad alloc exec -i -t=true -task cockroach $(shell nomad status cockroach | grep "running" | grep "cockroach-1" | head -n 1 | awk '{print $$1}') cockroach sql --insecure --host=localhost:26258
 
 .PHONY: nomad/bootstrap
 nomad/bootstrap: ## Bootstraps the ACL system on the Nomad cluster

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,10 @@ nomad/cockroachdb: ## Runs a Cockroach DB cluster
 	@sleep 10s
 	@nomad alloc exec -i -t=false -task cockroach $(shell nomad status cockroach | grep "running" | grep "cockroach-1" | head -n 1 | awk '{print $$1}') cockroach node ls --insecure --host=localhost:26258
 
+.PHONY: cockroachdb
+nomad/cockroachdb/sql: ## Start an interactive Cockroach DB SQL shell
+	@nomad alloc exec -i -t=true -task cockroach $(nomad status cockroach | grep "running" | grep "cockroach-1" | head -n 1 | awk '{print $1}') cockroach sql --insecure --host=localhost:26258
+
 .PHONY: nomad/bootstrap
 nomad/bootstrap: ## Bootstraps the ACL system on the Nomad cluster
 	@nomad acl bootstrap

--- a/jobs/db/cockroach.hcl
+++ b/jobs/db/cockroach.hcl
@@ -21,35 +21,55 @@ job "cockroach" {
   group "cockroach-1" {
     network {
       mode = "bridge"
+      port "metrics" {}
     }
 
     service {
-        name = "cockroach"
-        port = "26258"
-
-        connect {
-            sidecar_service {}
-        }
+      name = "cockroach-metrics"
+      port = "metrics"
+      connect {
+				sidecar_service {
+					proxy {
+						expose {
+							path {
+								path = "/_status/vars"
+								protocol = "http"
+								listener_port = "metrics"
+								local_path_port = 8080
+							}
+						}
+					}
+				}
+			}
     }
 
     service {
-        name = "cockroach-1"
-        port = "26258"
+      name = "cockroach"
+      port = "26258"
 
-        connect {
-            sidecar_service {
-                proxy {
-                    upstreams {
-                        destination_name = "cockroach-2"
-                        local_bind_port  = 26259
-                    }
-                    upstreams {
-                        destination_name = "cockroach-3"
-                        local_bind_port  = 26260
-                    }
-                }
+      connect {
+        sidecar_service {}
+      }
+    }
+
+    service {
+      name = "cockroach-1"
+      port = "26258"
+
+      connect {
+        sidecar_service {
+          proxy {
+            upstreams {
+              destination_name = "cockroach-2"
+              local_bind_port  = 26259
             }
+            upstreams {
+              destination_name = "cockroach-3"
+              local_bind_port  = 26260
+            }
+          }
         }
+      }
     }
 
     ephemeral_disk {
@@ -67,6 +87,7 @@ job "cockroach" {
           "--insecure",
           "--advertise-addr=localhost:26258",
           "--listen-addr=localhost:26258",
+          "--http-addr=0.0.0.0:8080",
           "--join=localhost:26258,localhost:26259,localhost:26260",
           "--logtostderr=INFO",
         ]
@@ -76,36 +97,56 @@ job "cockroach" {
 
   group "cockroach-2" {
     network {
-        mode = "bridge"
+      mode = "bridge"
+      port "metrics" {}
     }
 
     service {
-        name = "cockroach"
-        port = "26259"
-
-        connect {
-            sidecar_service {}
-        }
+      name = "cockroach-metrics"
+      port = "metrics"
+      connect {
+				sidecar_service {
+					proxy {
+						expose {
+							path {
+								path = "/_status/vars"
+								protocol = "http"
+								listener_port = "metrics"
+								local_path_port = 8080
+							}
+						}
+					}
+				}
+			}
     }
 
     service {
-        name = "cockroach-2"
-        port = "26259"
+      name = "cockroach"
+      port = "26259"
 
-        connect {
-            sidecar_service {
-                proxy {
-                    upstreams {
-                        destination_name = "cockroach-1"
-                        local_bind_port  = 26258
-                    }
-                    upstreams {
-                        destination_name = "cockroach-3"
-                        local_bind_port  = 26260
-                    }
-                }
+      connect {
+        sidecar_service {}
+      }
+    }
+
+    service {
+      name = "cockroach-2"
+      port = "26259"
+
+      connect {
+        sidecar_service {
+          proxy {
+            upstreams {
+              destination_name = "cockroach-1"
+              local_bind_port  = 26258
             }
+            upstreams {
+              destination_name = "cockroach-3"
+              local_bind_port  = 26260
+            }
+          }
         }
+      }
     }
 
     ephemeral_disk {
@@ -122,6 +163,7 @@ job "cockroach" {
           "start",
           "--insecure",
           "--advertise-addr=localhost:26259",
+          "--http-addr=0.0.0.0:8080",
           "--listen-addr=localhost:26259",
           "--join=localhost:26258,localhost:26259,localhost:26260",
           "--logtostderr=INFO",
@@ -132,7 +174,27 @@ job "cockroach" {
 
   group "cockroach-3" {
     network {
-        mode = "bridge"
+      mode = "bridge"
+      port "metrics" {}
+    }
+
+    service {
+      name = "cockroach-metrics"
+      port = "metrics"
+      connect {
+				sidecar_service {
+					proxy {
+						expose {
+							path {
+								path = "/_status/vars"
+								protocol = "http"
+								listener_port = "metrics"
+								local_path_port = 8080
+							}
+						}
+					}
+				}
+			}
     }
 
     service {
@@ -140,28 +202,28 @@ job "cockroach" {
         port = "26260"
 
         connect {
-            sidecar_service {}
+          sidecar_service {}
         }
     }
 
     service {
-        name = "cockroach-3"
-        port = "26260"
+      name = "cockroach-3"
+      port = "26260"
 
-        connect {
-            sidecar_service {
-                proxy {
-                    upstreams {
-                        destination_name = "cockroach-1"
-                        local_bind_port  = 26258
-                    }
-                    upstreams {
-                        destination_name = "cockroach-2"
-                        local_bind_port  = 26259
-                    }
-                }
+      connect {
+        sidecar_service {
+          proxy {
+            upstreams {
+              destination_name = "cockroach-1"
+              local_bind_port  = 26258
             }
+            upstreams {
+              destination_name = "cockroach-2"
+              local_bind_port  = 26259
+            }
+          }
         }
+      }
     }
 
     ephemeral_disk {
@@ -178,6 +240,7 @@ job "cockroach" {
           "start",
           "--insecure",
           "--advertise-addr=localhost:26260",
+          "--http-addr=0.0.0.0:8080",
           "--listen-addr=localhost:26260",
           "--join=localhost:26258,localhost:26259,localhost:26260",
           "--logtostderr=INFO",

--- a/jobs/db/cockroach.hcl
+++ b/jobs/db/cockroach.hcl
@@ -10,7 +10,8 @@ job "cockroach" {
 
   update {
     max_parallel     = 1
-    stagger          = "12s"
+    stagger          = "30s"
+    min_healthy_time = "30s"
     healthy_deadline = "3m"
   }
 

--- a/jobs/db/cockroach.hcl
+++ b/jobs/db/cockroach.hcl
@@ -24,6 +24,15 @@ job "cockroach" {
     }
 
     service {
+        name = "cockroach"
+        port = "26258"
+
+        connect {
+            sidecar_service {}
+        }
+    }
+
+    service {
         name = "cockroach-1"
         port = "26258"
 
@@ -71,6 +80,15 @@ job "cockroach" {
     }
 
     service {
+        name = "cockroach"
+        port = "26259"
+
+        connect {
+            sidecar_service {}
+        }
+    }
+
+    service {
         name = "cockroach-2"
         port = "26259"
 
@@ -115,6 +133,15 @@ job "cockroach" {
   group "cockroach-3" {
     network {
         mode = "bridge"
+    }
+
+    service {
+        name = "cockroach"
+        port = "26260"
+
+        connect {
+            sidecar_service {}
+        }
     }
 
     service {

--- a/jobs/db/cockroach.hcl
+++ b/jobs/db/cockroach.hcl
@@ -89,7 +89,7 @@ job "cockroach" {
           "--listen-addr=localhost:26258",
           "--http-addr=0.0.0.0:8080",
           "--join=localhost:26258,localhost:26259,localhost:26260",
-          "--logtostderr=INFO",
+          "--logtostderr=WARNING",
         ]
       }
     }
@@ -166,7 +166,7 @@ job "cockroach" {
           "--http-addr=0.0.0.0:8080",
           "--listen-addr=localhost:26259",
           "--join=localhost:26258,localhost:26259,localhost:26260",
-          "--logtostderr=INFO",
+          "--logtostderr=WARNING",
         ]
       }
     }
@@ -243,7 +243,7 @@ job "cockroach" {
           "--http-addr=0.0.0.0:8080",
           "--listen-addr=localhost:26260",
           "--join=localhost:26258,localhost:26259,localhost:26260",
-          "--logtostderr=INFO",
+          "--logtostderr=WARNING",
         ]
       }
     }

--- a/jobs/metrics/metrics.hcl
+++ b/jobs/metrics/metrics.hcl
@@ -121,6 +121,19 @@ scrape_configs:
         key_file: '/local/consul-cli-key.pem'
         insecure_skip_verify: false
       services: ['fuzz']
+  - job_name: 'cockroach_metrics'
+    metrics_path: /_status/vars
+    consul_sd_configs:
+    - server: '${var.consul_lb_ip}:8501'
+      token: '${var.consul_acl_token}'
+      datacenter: 'dc1'
+      scheme: 'https'
+      tls_config:
+        ca_file: '/local/consul-ca.pem'
+        cert_file: '/local/consul-cli-cert.pem'
+        key_file: '/local/consul-cli-key.pem'
+        insecure_skip_verify: false
+      services: ['cockroach-metrics']
   - job_name: 'consul_metrics'
     scrape_interval: 5s
     metrics_path: /v1/agent/metrics


### PR DESCRIPTION
Other services within the mesh can now just reference the cockroach instances in their upstreams using "cockroach" as a service name instead of worrying about their suffixes used for cockroach-only communication. Solving service problems with more service mesh.