### PR TITLE
Add example optional TimescaleDB and Promscale job file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DNS_ENABLED ?= false
 PUBLIC_DOMAIN ?= ""
 GRAFANA_LOAD_BALANCER_ENABLED ?= false
 GRAFANA_PUBLIC_DOMAIN ?= ""
+PROMSCALE_ENABLED ?= false
 
 .PHONY: help
 help: ## Print this help menu
@@ -173,7 +174,7 @@ consul/metrics/acls: ## Create a Consul policy, role, and token to use with prom
 
 .PHONY: nomad/metrics
 nomad/metrics: ## Runs a Prometheus and Grafana stack on Nomad
-	@nomad run -var='consul_targets=[$(shell terraform output -json | jq -r '(.server_internal_ips.value + .client_internal_ips.value) | map(.+":8501") |  @csv')]' -var="consul_acl_token=$(consul_acl_token)" -var="consul_lb_ip=$(shell terraform output load_balancer_ip)" jobs/metrics/metrics.hcl
+	@nomad run -var='promscale=$(PROMSCALE_ENABLED)' -var='consul_targets=[$(shell terraform output -json | jq -r '(.server_internal_ips.value + .client_internal_ips.value) | map(.+":8501") |  @csv')]' -var="consul_acl_token=$(consul_acl_token)" -var="consul_lb_ip=$(shell terraform output load_balancer_ip)" jobs/metrics/metrics.hcl
 
 .PHONY: nomad/logs
 nomad/logs: ## Runs a Loki and Promtail jobs on Nomad

--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ Logs can also be collected within the cluster using Promtail and Loki, then visu
 ```console
 $ DNS_ENABLED=true PUBLIC_DOMAIN="nomad.your-domain.com" make terraform/apply
 ...
-$ export NOMAD_TOKEN=...
-$ export CONSUL_HTTP_TOKEN=...
+$ export CONSUL_HTTP_TOKEN=$(terraform output -json | jq -r .consul_master_token.value)
 $ make consul/metrics/acls
 ...
 🔑 Creating Consul ACL Token to Use for Prometheus Consul Service Discovery
@@ -105,6 +104,7 @@ $ consul_acl_token=2a1c7926-b6e3-566e-ddf5-b19279fa134e make nomad/metrics
 $ make nomad/logs
 $ make nomad/ingress
 $ GRAFANA_PUBLIC_DOMAIN="grafana.your-domain.com" GRAFANA_LOAD_BALANCER_ENABLED=true DNS_ENABLED=true PUBLIC_DOMAIN="nomad.your-domain.com" make terraform/apply
+$ open http://public.grafana.your-domain.com:3000/login
 ```
 
 ## Bootstrap ACL Token

--- a/jobs/db/timescale.hcl
+++ b/jobs/db/timescale.hcl
@@ -1,0 +1,98 @@
+// docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb:latest-pg12
+variable "datacenters" {
+  type    = list(string)
+  default = ["dc1"]
+}
+
+job "timescaledb" {
+    datacenters = var.datacenters
+
+    group "timescaledb" {
+        network {
+            mode = "bridge"
+        }
+
+        service {
+            name = "timescaledb"
+            port = "5432"
+
+            connect {
+                sidecar_service {}
+            }
+        }
+
+        ephemeral_disk {
+            size    = 10240 # 10 GB
+            migrate = true
+            sticky  = true
+        }
+
+        task "timescaledb" {
+            driver = "docker"
+
+            # Note, configuration is found at:
+            # /var/lib/postgresql/data/postgresql.conf
+
+            env {
+                POSTGRES_PASSWORD = "password"
+            }
+
+            config {
+                image = "timescale/timescaledb:latest-pg12"
+            }
+        }
+    }
+
+    group "promscale" {
+        network {
+            mode = "bridge"
+        }
+
+        service {
+            name = "promscale"
+            port = "9201"
+
+            connect {
+                sidecar_service {
+                    proxy {
+                        upstreams {
+                            destination_name = "timescaledb"
+                            local_bind_port  = 5432
+                        }
+                    }
+                }
+            }
+        }
+
+        ephemeral_disk {
+            size    = 10240 # 10 GB
+            migrate = true
+            sticky  = true
+        }
+
+        task "promscale" {
+            driver = "docker"
+
+            env {
+                POSTGRES_PASSWORD = "password"
+
+                // PROMSCALE_WEB_TELEMETRY_PATH = "/metrics"
+                // PROMSCALE_DB_CONNECT_RETRIES = 10
+                // PROMSCALE_LOG_LEVEL = "info"
+                // PROMSCALE_DB_NAME = "timescale"
+                // PROMSCALE_DB_PORT = 5432
+                // PROMSCALE_DB_SSL_MODE = "allow"
+                // PROMSCALE_DB_HOST="127.0.0.1"
+                // PROMSCALE_DB_URI = ""
+            }
+
+            config {
+                image = "timescale/promscale:latest"
+
+                args = [
+                    "-db-uri", "postgres://postgres:$POSTGRES_PASSWORD@127.0.0.1:5432/postgres?sslmode=allow",
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an example [TimescaleDB](https://www.timescale.com/) and [Promscale](https://github.com/timescale/promscale) job file that can be optionally used in combination with the existing [metrics](https://github.com/picatz/terraform-google-nomad/blob/64da5ec4182a6c55249d9d8fdbc7a3dc4e66dc7e/jobs/metrics/metrics.hcl) job file. Serves as a starting point, not a production-ready example.
