### PR TITLE
Add `plugin` stanza to configure Docker task driver on clients

### DIFF
--- a/packer/configs/nomad/client.hcl
+++ b/packer/configs/nomad/client.hcl
@@ -61,3 +61,33 @@ telemetry {
   publish_allocation_metrics = true
   publish_node_metrics       = true
 }
+
+plugin "docker" {
+  config {
+    endpoint = "unix:///var/run/docker.sock"
+
+    allow_runtimes = ["runc","runsc"]
+
+    allow_privileged = false
+
+    // auth {
+    //   config = "/nomad/config/docker_auth_config.json"
+    //   helper = "gcr"
+    // }
+
+    extra_labels = ["job_name", "job_id", "task_group_name", "task_name", "namespace", "node_name", "node_id"]
+
+    gc {
+      image       = true
+      image_delay = "3m"
+      container   = true
+
+      dangling_containers {
+        enabled        = true
+        dry_run        = false
+        period         = "5m"
+        creation_grace = "5m"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The main change being the `allow_runtimes` value which enables the `runsc` runtime (gVisor), not enabled by default. This actually allows submitted Docker tasks to use the `runtime = "runsc"` configuration value. 

Note: this doesn't seem to work with Falco monitoring, which seems to only support the default `runc` runtime. It also seems to introduce some health check problems with Consul's service mesh capabilities, but I'm not sure of the cause (I believe the error was "no route to host" in the UI).