### PR TITLE
Add initial implementation of a traefik+consul job template

### DIFF
--- a/jobs/ingress/services.hcl
+++ b/jobs/ingress/services.hcl
@@ -1,0 +1,6 @@
+consul_services = [
+  {
+    name = "grafana"
+    port = 3000
+  }
+]

--- a/jobs/ingress/traefik_template.hcl
+++ b/jobs/ingress/traefik_template.hcl
@@ -1,0 +1,145 @@
+variable "datacenters" {
+  type    = list(string)
+  default = ["dc1"]
+}
+
+variable "traefik_log_level" {
+  type    = string
+  default = "DEBUG"
+}
+
+variable "consul_services" {
+  type = list(object({
+    name = string
+    port = number
+  }))
+  default = [
+      {
+          name    = "grafana"
+          port    = 3000
+      }
+  ]
+}
+
+// TODO: consider option to optionally enable/disable the dashboard and metrics listeners
+
+locals {
+    dynamic_entry_points = [for i, service in var.consul_services : format("    [entryPoints.%s]\n      address = \"%d\"", service.name, service.port)]
+
+    traefik_toml = <<EOT
+[entryPoints]
+${join("\n", local.dynamic_entry_points)}
+    [entryPoints.traefik]
+      address = ":8081"
+    [entryPoints.metrics]
+      address = ":8082"
+
+[metrics]
+  [metrics.prometheus]
+    addEntryPointsLabels = true
+
+[log]
+    level = "${var.traefik_log_level}"
+    format = "json"
+
+[accessLog]
+    format = "json"
+
+[api]
+    dashboard = true
+    insecure  = true
+
+[providers]
+  [providers.file]
+    directory = "/local/traefik"
+    EOT
+
+    dynamic_routers = [for i, service in var.consul_services : format("  [tcp.routers.%s]\n    entryPoints = [%q]\n    rule = %q\n    service = %q", service.name, service.name, "HostSNI(`*`)", service.port)]
+
+    dynamic_services = [for i, service in var.consul_services : format("  [tcp.services.%s.loadBalancer]\n    [[tcp.services.%s.loadBalancer.servers]]\n      address = \"localhost:%d\"", service.name, service.name, service.port + 1)]
+
+    conf = <<EOT
+[tcp.routers]
+${join("\n", local.dynamic_routers)}
+
+[tcp.services]
+${join("\n", local.dynamic_services)}
+    EOT
+}
+
+job "ingress" {
+    datacenters = var.datacenters
+    type = "system"
+
+    group "traefik" {
+        count = 1
+
+        network {
+            mode = "bridge"
+
+            dynamic "port" {
+              for_each = var.consul_services
+              iterator = service
+              labels = [service.value.name]
+              content {
+                static = service.value.port
+                to     = service.value.port
+              }
+            }
+
+            port "dashboard" {
+                static = 8081
+                to     = 8081
+            }
+
+            port "metrics" {
+                static = 8082
+                to     = 8082
+            }
+        }
+
+        dynamic "service" {
+            for_each = var.consul_services
+            iterator = service
+            content {
+              name = "traefik-${service.value.name}"
+              port  = service.value.name
+
+              connect {
+                sidecar_service {
+                    proxy {
+                        upstreams {
+                            destination_name = service.value.name
+                            local_bind_port  = service.value.port + 1
+                        }
+                    }
+                }
+              }
+            }
+        }
+
+        task "traefik" {
+            template {
+                change_mode = "restart"
+                destination = "local/traefik.toml"
+                data        = local.traefik_toml
+            }
+
+            template {
+                change_mode = "restart"
+                destination = "local/traefik/conf.toml"
+                data        = local.conf
+            }
+
+            driver = "docker"
+
+            config {
+                image = "traefik:latest"
+
+                volumes = [
+                    "local/traefik.toml:/etc/traefik/traefik.toml"
+                ]
+            }
+        }
+    }
+}

--- a/jobs/ingress/traefik_template.hcl
+++ b/jobs/ingress/traefik_template.hcl
@@ -24,7 +24,7 @@ variable "consul_services" {
 // TODO: consider option to optionally enable/disable the dashboard and metrics listeners
 
 locals {
-    dynamic_entry_points = [for i, service in var.consul_services : format("    [entryPoints.%s]\n      address = \"%d\"", service.name, service.port)]
+    dynamic_entry_points = [for i, service in var.consul_services : format("    [entryPoints.%s]\n      address = \":%d\"", service.name, service.port)]
 
     traefik_toml = <<EOT
 [entryPoints]


### PR DESCRIPTION
This PR adds a better template-ized version of the current [`traefik.hcl`](https://github.com/picatz/terraform-google-nomad/blob/511c11f9b749af7f3f67a5aff5f5b761cb5d9f0b/jobs/ingress/traefik.hcl) job. This allows new services to be added easier without needing to repeat the same thing over-and-over.

## Example Usage

```console
$ cat services.hcl
consul_services = [
  {
    name = "grafana"
    port = 3000
  }
]
$ nomad plan -verbose -var-file=services.hcl traefik_template.hcl
$ nomad run -verbose -var-file=services.hcl traefik_template.hcl
```

Which will result in the following system job on each client node to handle ingress traffic with Traefik, through to a Consul service mesh using Envoy:

<img width="1172" alt="Screen Shot 2021-09-22 at 9 59 38 PM" src="https://user-images.githubusercontent.com/14850816/134444486-86fe502d-4c36-4d2f-b9d7-1a238b6a07d7.png">

So that, at a high-level, this can be achieved: 

![gcp_nomad_traefik_consol_envoy_grafana](https://user-images.githubusercontent.com/14850816/134446810-3357af38-b0ca-454f-a967-d26475bf3a90.png)



## Dynamically Generated Configuration

To get a better idea of how this config is dynamically generated from the `consul_services` variable, here are some examples:

### Dynamically Generated Static Ingress Port Allocations for Services

This `dynamic` block in the job definition will configure a [`port`](https://www.nomadproject.io/docs/job-specification/network#port-parameters) allocation for the service:

```hcl
dynamic "port" {
  for_each = var.consul_services
  iterator = service
  labels = [service.value.name]
  content {
    static = service.value.port
    to     = service.value.port
  }
}
```

Which, for the default value, and example variable file, would result in:

```hcl
port "grafana" {
  static = 3000
  to     = 3000
}
```

These allocated ports are the ports that you'll use in your cloud load balancer configurations to handle sending ingress traffic to Nomad using Terraform.

```hcl
module "grafana_load_balancer" {
  source            = "./modules/load-balancer"
  enabled           = var.grafana_load_balancer_enabled
  region            = var.region
  name              = "grafana-load-balancer"
  ports             = [3000]
  health_check_port = 3000
  target_tags       = ["client"]
  network           = module.network.name
  instances         = formatlist("${format("%s-%s/client", var.region, var.zone)}-%d", range(var.client_instances))
  and_depends_on    = [module.network]
}
```

### Dynamically Generated Consul Service Upstreams

```hcl
dynamic "service" {
  for_each = var.consul_services
  iterator = service
  content {
    name = "traefik-${service.value.name}"
    port  = service.value.name

    connect {
      sidecar_service {
        proxy {
          upstreams {
            destination_name = service.value.name
            local_bind_port  = service.value.port + 1
          }
        }
      }
    }
  }
}
```

```hcl
service {
  name = "traefik-grafana"
  port = "grafana"

  connect {
    sidecar_service {
      proxy {
        upstreams {
          destination_name = "grafana"
          local_bind_port  = 3001
        }
      }
    }
  }
}
```

### Dynamically Generated Traefik TOML

```hcl
locals {
  dynamic_entry_points = [for i, service in var.consul_services : format("    [entryPoints.%s]\n      address = \":%d\"", service.name, service.port)]

  traefik_toml = <<EOT
[entryPoints]
${join("\n", local.dynamic_entry_points)}

... removed some content not related to entrypoints for brevity ...
  EOT
}
```

```toml
[entryPoints]
    [entryPoints.grafana]
      address = ":3000"
```