### PR TITLE
network: add empty `source_tags` to ICMP firewall rule

### DIFF
--- a/modules/network/network.tf
+++ b/modules/network/network.tf
@@ -18,6 +18,8 @@ resource "google_compute_firewall" "allow_icmp" {
   allow {
     protocol = "icmp"
   }
+
+  source_tags = []
 }
 
 module "ssh" {


### PR DESCRIPTION
The `google_compute_firewall` resource expects one of `source_tags`,
`source_ranges`, or `source_service_accounts` to be defined. Provide
an empty `source_tags` to prevent an error during Terraform planning.

---

Error presents like the following without this patch:

```
$ terraform plan -var="project=$GOOGLE_PROJECT" -var="credentials=$GOOGLE_APPLICATION_CREDENTIALS"
╷
│ Error: 1 error occurred:
│   * one of source_tags, source_ranges, or source_service_accounts must be defined
│
│
│
│   with module.network.google_compute_firewall.allow_icmp,
│   on modules/network/network.tf line 14, in resource "google_compute_firewall" "allow_icmp":
│   14: resource "google_compute_firewall" "allow_icmp" {
│
╵
```

Note that it looks like this repo is also impacted by https://github.com/hashicorp/terraform-provider-google/issues/10894 but that's upstream. 😀 